### PR TITLE
Fix OC splitter startup script

### DIFF
--- a/bin/scripts/service_workerOC_splitter.sh
+++ b/bin/scripts/service_workerOC_splitter.sh
@@ -22,4 +22,4 @@ export MAGICK_TMPDIR=/tmp/opencaptureforinvoices/
 export TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata/
 
 cd /var/www/html/opencaptureforinvoices/ || exit
-/usr/local/bin/kuyruk --app src.backend.main_splitter.OCforInvoices worker --queue splitter
+/usr/local/bin/kuyruk --app src.backend.main_splitter.OCforInvoices_worker worker --queue splitter


### PR DESCRIPTION
Due to commit fffc1da4c9c665a0f7323836680d249057d13698, OC splitter was not starting anymore with service_workerOC_splitter.sh.
